### PR TITLE
fix: make action run on any PR

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,10 +4,7 @@
 name: Node.js CI
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
Make workflows run on any PR, not just PRs to `main`. This will let us see that tests have passed even when doing stacked PRs