### PR TITLE
chore: update package-lock to version 0.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reading-log-back",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "reading-log-back",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^9.0.0",


### PR DESCRIPTION
This updates the package-lock, which was not properly updated for v0.0.3.