### PR TITLE
Use authorization for `OwnedEntities` on `findOne` and `findAll` routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Authorization module
 
 ### Changed
-- `/users/` route to pass authorization for PATCH, POST, and DELETE
-- `/authors/` route to pass authorization for PATCH, POST, and DELETE
-- `/books/` route to pass authorization for PATCH, POST, and DELETE
-- `/notes/` route to pass authorization for PATCH, POST, and DELETE
-- `/readings/` route to pass authorization for PATCH, POST, and DELETE
-- `/languages/` route to pass authorization for PATCH, POST, and DELETE
+- `/users/` route to pass authorization for GET, PATCH, POST, and DELETE
+- `/authors/` route to pass authorization for GET, PATCH, POST, and DELETE
+- `/books/` route to pass authorization for GET, PATCH, POST, and DELETE
+- `/notes/` route to pass authorization for GET, PATCH, POST, and DELETE
+- `/readings/` route to pass authorization for GET, PATCH, POST, and DELETE
+- `/languages/` route to pass authorization for GET, PATCH, POST, and DELETE
 
 ## [0.0.3] - 2022-08-09
 ### Added

--- a/src/auth/auth.decorator.ts
+++ b/src/auth/auth.decorator.ts
@@ -1,0 +1,16 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+
+export const AuthUser = createParamDecorator(
+  (_: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    if (!request?.user) {
+      throw new UnauthorizedException('No authenticated user');
+    }
+    console.log(request.user);
+    return request.user;
+  },
+);

--- a/src/authors/authors.controller.ts
+++ b/src/authors/authors.controller.ts
@@ -4,6 +4,7 @@ import { AuthorPoliciesGuard } from '@/casl/guards/authorPolicy.guard';
 import {
   CreateGenericPolicyHandler,
   DeleteGenericPolicyHandler,
+  ReadGenericPolicyHandler,
   UpdateGenericPolicyHandler,
 } from '@/casl/handlers/GenericPolicy.handler';
 import { AuthUserToken } from '@/common/dto/auth-user-payload.dto';
@@ -88,6 +89,8 @@ export class AuthorsController {
     });
   }
 
+  @UseGuards(AuthorPoliciesGuard)
+  @CheckPolicies(new ReadGenericPolicyHandler())
   @Get(':id')
   findOne(@Param('id', ParseIntPipe) id: number): Promise<Author | null> {
     return this.authorsService.findOne(id);

--- a/src/authors/authors.controller.ts
+++ b/src/authors/authors.controller.ts
@@ -71,9 +71,9 @@ export class AuthorsController {
     });
   }
 
+  @Get(':id')
   @UseGuards(AuthorPoliciesGuard)
   @CheckPolicies(new ReadGenericPolicyHandler())
-  @Get(':id')
   findOne(@Param('id', ParseIntPipe) id: number): Promise<Author | null> {
     return this.authorsService.findOne(id);
   }

--- a/src/authors/authors.service.ts
+++ b/src/authors/authors.service.ts
@@ -1,7 +1,12 @@
 import { User } from '@/users/entities/user.entity';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DeleteResult, Repository, UpdateResult } from 'typeorm';
+import {
+  DeleteResult,
+  FindManyOptions,
+  Repository,
+  UpdateResult,
+} from 'typeorm';
 import { CreateAuthorDto } from './dto/create-author.dto';
 import { UpdateAuthorDto } from './dto/update-author.dto';
 import { Author } from './entities/author.entity';
@@ -25,12 +30,12 @@ export class AuthorsService {
     return this.authorRepository.save(author);
   }
 
-  findAll(): Promise<Author[]> {
-    return this.authorRepository.find();
+  findAll(query?: FindManyOptions<Author>): Promise<Author[]> {
+    return this.authorRepository.find(query);
   }
 
   findOne(id: number): Promise<Author | null> {
-    return this.authorRepository.findOneBy({ id: id });
+    return this.authorRepository.findOneByOrFail({ id: id });
   }
 
   update(id: number, updateAuthorDto: UpdateAuthorDto): Promise<UpdateResult> {

--- a/src/authors/dto/query-author.dto.ts
+++ b/src/authors/dto/query-author.dto.ts
@@ -1,0 +1,10 @@
+import { PartialType, PickType } from '@nestjs/swagger';
+import { Author } from '../entities/author.entity';
+
+export class QueryAuthorDto extends PickType(PartialType(Author), [
+  'id',
+  'firstNames',
+  'lastName',
+  'ownerId',
+  'isPublic',
+]) {}

--- a/src/authors/dto/query-author.dto.ts
+++ b/src/authors/dto/query-author.dto.ts
@@ -3,8 +3,10 @@ import { Author } from '../entities/author.entity';
 
 export class QueryAuthorDto extends PickType(PartialType(Author), [
   'id',
-  'firstNames',
-  'lastName',
   'ownerId',
   'isPublic',
+  'createdAt',
+  'updatedAt',
+  'firstNames',
+  'lastName',
 ]) {}

--- a/src/books/books.service.ts
+++ b/src/books/books.service.ts
@@ -3,7 +3,12 @@ import { Language } from '@/languages/entities/language.entity';
 import { User } from '@/users/entities/user.entity';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DeleteResult, Repository, UpdateResult } from 'typeorm';
+import {
+  DeleteResult,
+  FindManyOptions,
+  Repository,
+  UpdateResult,
+} from 'typeorm';
 import { CreateBookDto } from './dto/create-book.dto';
 import { UpdateBookDto } from './dto/update-book.dto';
 import { Book } from './entities/book.entity';
@@ -40,12 +45,12 @@ export class BooksService {
     return this.bookRepository.save(book);
   }
 
-  findAll(): Promise<Book[]> {
-    return this.bookRepository.find();
+  findAll(query?: FindManyOptions<Book>): Promise<Book[]> {
+    return this.bookRepository.find(query);
   }
 
   findOne(id: number): Promise<Book | null> {
-    return this.bookRepository.findOneBy({ id: id });
+    return this.bookRepository.findOneByOrFail({ id: id });
   }
 
   update(id: number, updateBookDto: UpdateBookDto): Promise<UpdateResult> {

--- a/src/books/dto/query-book.dto.ts
+++ b/src/books/dto/query-book.dto.ts
@@ -1,0 +1,18 @@
+import { PartialType, PickType } from '@nestjs/swagger';
+import { Book } from '../entities/book.entity';
+
+export class QueryBookDto extends PickType(PartialType(Book), [
+  'id',
+  'ownerId',
+  'isPublic',
+  'createdAt',
+  'updatedAt',
+  'title',
+  'author',
+  'authorId',
+  'edition',
+  'language',
+  'languageId',
+  'length',
+  'publicationDate',
+]) {}

--- a/src/casl/handlers/GenericPolicy.handler.ts
+++ b/src/casl/handlers/GenericPolicy.handler.ts
@@ -20,6 +20,21 @@ export class CreateGenericPolicyHandler implements IPolicyHandler {
   }
 }
 
+export class ReadGenericPolicyHandler implements IPolicyHandler {
+  private readonly logger = new Logger(ReadGenericPolicyHandler.name);
+
+  handle(ability: AppAbility, subject: Subjects, fields: Fields) {
+    this.logger.debug(`Subject: ${JSON.stringify(subject)}`);
+    this.logger.debug(`Fields: ${JSON.stringify(fields)}`);
+    const isAuth = ability.can(
+      Action.Read,
+      new OwnedEntity(subject as OwnedEntity),
+    );
+    this.logger.debug(`Is Authorized: ${JSON.stringify(isAuth)}`);
+    return isAuth;
+  }
+}
+
 export class UpdateGenericPolicyHandler implements IPolicyHandler {
   handle(ability: AppAbility, subject: Subjects, fields?: Fields) {
     let isAuth = true;

--- a/src/common/dto/auth-user-payload.dto.ts
+++ b/src/common/dto/auth-user-payload.dto.ts
@@ -1,0 +1,4 @@
+export interface AuthUserToken {
+  userId: number;
+  username: string;
+}

--- a/src/common/dto/query-owned.dto.ts
+++ b/src/common/dto/query-owned.dto.ts
@@ -1,0 +1,8 @@
+import { PartialType, PickType } from '@nestjs/swagger';
+import { OwnedEntity } from '../entities/owned.entity';
+
+export class QueryOwnedDto extends PickType(PartialType(OwnedEntity), [
+  'id',
+  'ownerId',
+  'isPublic',
+]) {}

--- a/src/common/entities/owned.entity.ts
+++ b/src/common/entities/owned.entity.ts
@@ -1,5 +1,6 @@
 import { User } from '@/users/entities/user.entity';
 import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
 import {
   IsBoolean,
   IsDate,
@@ -30,6 +31,7 @@ export class OwnedEntity {
   })
   @IsPositive()
   @IsInt()
+  @Type(() => Number)
   @PrimaryGeneratedColumn()
   id: number;
 
@@ -46,6 +48,7 @@ export class OwnedEntity {
   })
   @IsInt()
   @IsPositive()
+  @Type(() => Number)
   @RelationId((owned: OwnedEntity) => owned.owner)
   ownerId: number;
 
@@ -67,6 +70,7 @@ export class OwnedEntity {
     description: 'Whether or not the Entity is Public',
   })
   @IsBoolean()
+  @Type(() => Boolean)
   @Column({ default: false })
   isPublic: boolean;
 }

--- a/src/common/getOwnedPublicQuery.ts
+++ b/src/common/getOwnedPublicQuery.ts
@@ -1,0 +1,21 @@
+import { FindOptionsWhere } from 'typeorm';
+import { AuthUserToken } from './dto/auth-user-payload.dto';
+import { OwnedEntity } from './entities/owned.entity';
+
+export function getOwnedPublicQuery<Entity extends OwnedEntity>(
+  user: AuthUserToken,
+  query?: FindOptionsWhere<Entity>,
+): Array<FindOptionsWhere<Entity>> {
+  const queries: Array<FindOptionsWhere<Entity>> = [];
+  const queryOwned: any = { ...query };
+  queryOwned.owner = { id: user.userId };
+  queryOwned.owner.id = user.userId;
+  const queryPublic: any = { ...query };
+  queryPublic.isPublic = true;
+
+  if (query?.isPublic === undefined || query?.isPublic === true)
+    queries.push(queryPublic);
+  if (query?.ownerId === undefined || query?.ownerId === user.userId)
+    queries.push(queryOwned);
+  return queries;
+}

--- a/src/common/interface/owned.interface.ts
+++ b/src/common/interface/owned.interface.ts
@@ -1,0 +1,7 @@
+import { FindOptionsWhereProperty } from 'typeorm';
+
+export interface OwnedInterface {
+  owner: FindOptionsWhereProperty<OwnedInterface>;
+  ownerId: number;
+  isPublic: FindOptionsWhereProperty<OwnedInterface>;
+}

--- a/src/languages/dto/query-language.dto.ts
+++ b/src/languages/dto/query-language.dto.ts
@@ -1,0 +1,11 @@
+import { PickType, PartialType } from '@nestjs/swagger';
+import { Language } from '../entities/language.entity';
+
+export class QueryLanguageDto extends PickType(PartialType(Language), [
+  'id',
+  'ownerId',
+  'isPublic',
+  'createdAt',
+  'updatedAt',
+  'name',
+]) {}

--- a/src/languages/languages.service.ts
+++ b/src/languages/languages.service.ts
@@ -1,7 +1,12 @@
 import { User } from '@/users/entities/user.entity';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DeleteResult, Repository, UpdateResult } from 'typeorm';
+import {
+  DeleteResult,
+  FindManyOptions,
+  Repository,
+  UpdateResult,
+} from 'typeorm';
 import { CreateLanguageDto } from './dto/create-language.dto';
 import { UpdateLanguageDto } from './dto/update-language.dto';
 import { Language } from './entities/language.entity';
@@ -24,12 +29,12 @@ export class LanguagesService {
     return this.languageRepository.save(language);
   }
 
-  findAll(): Promise<Language[]> {
-    return this.languageRepository.find();
+  findAll(query?: FindManyOptions<Language>): Promise<Language[]> {
+    return this.languageRepository.find(query);
   }
 
   findOne(id: number): Promise<Language | null> {
-    return this.languageRepository.findOneBy({ id: id });
+    return this.languageRepository.findOneByOrFail({ id: id });
   }
 
   update(

--- a/src/notes/dto/query-note.dto.ts
+++ b/src/notes/dto/query-note.dto.ts
@@ -3,6 +3,10 @@ import { Note } from '../entities/note.entity';
 
 export class QueryNoteDto extends PickType(PartialType(Note), [
   'id',
+  'owner',
+  'ownerId',
+  'createdAt',
+  'updatedAt',
   'author',
   'authorId',
   'book',
@@ -11,6 +15,4 @@ export class QueryNoteDto extends PickType(PartialType(Note), [
   'readingId',
   'page',
   'content',
-  'owner',
-  'ownerId',
 ]) {}

--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -4,8 +4,12 @@ import { Reading } from '@/readings/entities/reading.entity';
 import { User } from '@/users/entities/user.entity';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DeleteResult, Repository, UpdateResult } from 'typeorm';
-import { QueryNoteDto } from './dto/query-note.dto';
+import {
+  DeleteResult,
+  FindManyOptions,
+  Repository,
+  UpdateResult,
+} from 'typeorm';
 import { CreateNoteDto } from './dto/create-note.dto';
 import { UpdateNoteDto } from './dto/update-note.dto';
 import { Note } from './entities/note.entity';
@@ -48,12 +52,12 @@ export class NotesService {
     return this.noteRepository.save(note);
   }
 
-  findAll(query?: QueryNoteDto): Promise<Note[]> {
-    return this.noteRepository.find({ where: query });
+  findAll(query?: FindManyOptions<Note>): Promise<Note[]> {
+    return this.noteRepository.find(query);
   }
 
   findOne(id: number): Promise<Note | null> {
-    return this.noteRepository.findOneBy({ id: id });
+    return this.noteRepository.findOneByOrFail({ id: id });
   }
 
   update(id: number, updateNoteDto: UpdateNoteDto): Promise<UpdateResult> {

--- a/src/readings/dto/query-reading.dto.ts
+++ b/src/readings/dto/query-reading.dto.ts
@@ -1,0 +1,14 @@
+import { PartialType, PickType } from '@nestjs/swagger';
+import { Reading } from '../entities/reading.entity';
+
+export class QueryReadingDto extends PickType(PartialType(Reading), [
+  'id',
+  'ownerId',
+  'isPublic',
+  'createdAt',
+  'updatedAt',
+  'book',
+  'bookId',
+  'startDate',
+  'endDate',
+]) {}

--- a/src/readings/readings.service.ts
+++ b/src/readings/readings.service.ts
@@ -2,7 +2,7 @@ import { Book } from '@/books/entities/book.entity';
 import { User } from '@/users/entities/user.entity';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { FindManyOptions, Repository } from 'typeorm';
 import { CreateReadingDto } from './dto/create-reading.dto';
 import { UpdateReadingDto } from './dto/update-reading.dto';
 import { Reading } from './entities/reading.entity';
@@ -32,12 +32,12 @@ export class ReadingsService {
     return this.readingRepository.save(reading);
   }
 
-  findAll() {
-    return this.readingRepository.find();
+  findAll(query?: FindManyOptions<Reading>): Promise<Reading[]> {
+    return this.readingRepository.find(query);
   }
 
-  findOne(id: number) {
-    return this.readingRepository.findOneBy({ id: id });
+  findOne(id: number): Promise<Reading | null> {
+    return this.readingRepository.findOneByOrFail({ id: id });
   }
 
   update(id: number, updateReadingDto: UpdateReadingDto) {

--- a/test/author.e2e-spec.ts
+++ b/test/author.e2e-spec.ts
@@ -150,4 +150,16 @@ describe('AuthorController (e2e)', () => {
       expect(result.status).toBe(403);
     });
   });
+
+  describe('Private authors do not appear in findAll', () => {
+    it('/authors/ (GET)', async () => {
+      const result = await request(app.getHttpServer())
+        .get('/v1/authors/')
+        .set('Authorization', 'Bearer ' + token2);
+      expect(result.status).toBe(200);
+      for (const author of result.body) {
+        expect(author.ownerId).toBe(2);
+      }
+    });
+  });
 });

--- a/test/author.e2e-spec.ts
+++ b/test/author.e2e-spec.ts
@@ -123,7 +123,7 @@ describe('AuthorController (e2e)', () => {
     it('/authors/ (GET)', async () => {
       const result = await request(app.getHttpServer())
         .get('/v1/authors/1')
-        .set('Authorization', 'Bearer ' + token2);
+        .set('Authorization', 'Bearer ' + token1);
       expect(result.status).toBe(200);
       expect(result.body.firstNames).toEqual('Mark');
       expect(result.body.lastName).toEqual('Twine');


### PR DESCRIPTION
This protects the `GET` routes for all `OwnedEntities` (Author, Book, Reading, Language, Note)

Fix #74 